### PR TITLE
Support other migration foreign key methods

### DIFF
--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -8,6 +8,7 @@ class SnapshotBlueprint extends Blueprint
 {
     /**
      * {@inheritDoc}
+     *
      * @return SnapshotForeignKeyDefinition
      */
     public function foreign($columns, $name = null)
@@ -23,6 +24,7 @@ class SnapshotBlueprint extends Blueprint
 
     /**
      * {@inheritDoc}
+     *
      * @return SnapshotForeignIdColumnDefinition
      */
     public function foreignId($column)
@@ -37,6 +39,7 @@ class SnapshotBlueprint extends Blueprint
 
     /**
      * {@inheritDoc}
+     *
      * @return SnapshotForeignIdColumnDefinition
      */
     public function foreignUuid($column)
@@ -49,6 +52,7 @@ class SnapshotBlueprint extends Blueprint
 
     /**
      * {@inheritDoc}
+     *
      * @return SnapshotForeignIdColumnDefinition
      */
     public function foreignUlid($column, $length = 26)

--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -7,10 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 class SnapshotBlueprint extends Blueprint
 {
     /**
-     * Specify a foreign key for the table.
-     *
-     * @param  string|array  $columns
-     * @param  string|null  $name
+     * {@inheritDoc}
      * @return SnapshotForeignKeyDefinition
      */
     public function foreign($columns, $name = null)
@@ -22,5 +19,44 @@ class SnapshotBlueprint extends Blueprint
         $this->commands[count($this->commands) - 1] = $command;
 
         return $command;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return SnapshotForeignIdColumnDefinition
+     */
+    public function foreignId($column)
+    {
+        return $this->addColumnDefinition(new SnapshotForeignIdColumnDefinition($this, [
+            'type' => 'bigInteger',
+            'name' => $column,
+            'autoIncrement' => false,
+            'unsigned' => true,
+        ]));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return SnapshotForeignIdColumnDefinition
+     */
+    public function foreignUuid($column)
+    {
+        return $this->addColumnDefinition(new SnapshotForeignIdColumnDefinition($this, [
+            'type' => 'uuid',
+            'name' => $column,
+        ]));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return SnapshotForeignIdColumnDefinition
+     */
+    public function foreignUlid($column, $length = 26)
+    {
+        return $this->addColumnDefinition(new SnapshotForeignIdColumnDefinition($this, [
+            'type' => 'char',
+            'name' => $column,
+            'length' => $length,
+        ]));
     }
 }

--- a/src/Migrator/SnapshotForeignIdColumnDefinition.php
+++ b/src/Migrator/SnapshotForeignIdColumnDefinition.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Plank\Snapshots\Migrator;
+
+use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use Illuminate\Support\Str;
+
+class SnapshotForeignIdColumnDefinition extends ForeignIdColumnDefinition
+{
+    /**
+     * The schema builder blueprint instance.
+     *
+     * @var SnapshotBlueprint
+     */
+    protected $blueprint;
+
+    public function __construct(SnapshotBlueprint $blueprint, $attributes = [])
+    {
+        parent::__construct($blueprint, $attributes);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return SnapshotForeignKeyDefinition
+     */
+    public function constrainedToSnapshot($table = null, $column = 'id', $indexName = null)
+    {
+        return $this->references($column, $indexName)->onSnapshot($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return SnapshotForeignKeyDefinition
+     */
+    public function references($column, $indexName = null): SnapshotForeignKeyDefinition
+    {
+        return $this->blueprint->foreign($this->name, $indexName)->references($column);
+    }
+}

--- a/src/Migrator/SnapshotForeignIdColumnDefinition.php
+++ b/src/Migrator/SnapshotForeignIdColumnDefinition.php
@@ -21,6 +21,7 @@ class SnapshotForeignIdColumnDefinition extends ForeignIdColumnDefinition
 
     /**
      * {@inheritDoc}
+     *
      * @return SnapshotForeignKeyDefinition
      */
     public function constrainedToSnapshot($table = null, $column = 'id', $indexName = null)
@@ -30,7 +31,6 @@ class SnapshotForeignIdColumnDefinition extends ForeignIdColumnDefinition
 
     /**
      * {@inheritDoc}
-     * @return SnapshotForeignKeyDefinition
      */
     public function references($column, $indexName = null): SnapshotForeignKeyDefinition
     {

--- a/tests/Database/Migrations/pivot/2023_08_25_000002_create_projects_table.php
+++ b/tests/Database/Migrations/pivot/2023_08_25_000002_create_projects_table.php
@@ -11,7 +11,7 @@ return new class extends SnapshotMigration
     public function up(): void
     {
         $this->schema->create('projects', function (SnapshotBlueprint $table) {
-            $table->id();
+            $table->ulid('ulid')->primary();
             $table->string('name');
             $table->timestamps();
         });

--- a/tests/Database/Migrations/pivot/2023_08_25_000003_create_category_project_table.php
+++ b/tests/Database/Migrations/pivot/2023_08_25_000003_create_category_project_table.php
@@ -12,12 +12,11 @@ return new class extends SnapshotMigration
     {
         $this->schema->create('category_project', function (SnapshotBlueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('category_id');
-            $table->unsignedBigInteger('project_id');
+            $table->foreignId('category_id')->constrained('categories');
+            $table->foreignUlid('project_id')->constrainedToSnapshot('projects', 'ulid');
             $table->timestamps();
 
             $table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade');
-            $table->foreign('project_id')->references('id')->onSnapshot('projects')->onDelete('cascade');
         });
     }
 };

--- a/tests/Database/Migrations/pivot/2023_08_25_000005_create_product_projects_table.php
+++ b/tests/Database/Migrations/pivot/2023_08_25_000005_create_product_projects_table.php
@@ -12,13 +12,10 @@ return new class extends SnapshotMigration
     {
         $this->schema->create('product_project', function (SnapshotBlueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('product_id');
-            $table->unsignedBigInteger('project_id');
+            $table->foreignId('product_id')->constrainedToSnapshot('products');
+            $table->foreignId('project_id')->constrainedToSnapshot('projects');
             $table->unsignedInteger('quantity');
             $table->timestamps();
-
-            $table->foreign('product_id')->references('id')->onSnapshot('products')->onDelete('cascade');
-            $table->foreign('project_id')->references('id')->onSnapshot('projects')->onDelete('cascade');
         });
     }
 };

--- a/tests/Database/Migrations/pivot/2023_08_25_000005_create_product_projects_table.php
+++ b/tests/Database/Migrations/pivot/2023_08_25_000005_create_product_projects_table.php
@@ -13,7 +13,7 @@ return new class extends SnapshotMigration
         $this->schema->create('product_project', function (SnapshotBlueprint $table) {
             $table->id();
             $table->foreignId('product_id')->constrainedToSnapshot('products');
-            $table->foreignId('project_id')->constrainedToSnapshot('projects');
+            $table->foreignUlid('project_id')->constrainedToSnapshot('projects', 'ulid');
             $table->unsignedInteger('quantity');
             $table->timestamps();
         });

--- a/tests/Database/Migrations/pivot/2023_08_25_000006_create_tasks_table.php
+++ b/tests/Database/Migrations/pivot/2023_08_25_000006_create_tasks_table.php
@@ -13,11 +13,9 @@ return new class extends Migration
     {
         Schema::create('tasks', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('project_id');
+            $table->ulid('project_id');
             $table->string('name');
             $table->timestamps();
-
-            $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');
         });
     }
 };

--- a/tests/Database/Migrations/query/2023_08_25_000002_create_posts_table.php
+++ b/tests/Database/Migrations/query/2023_08_25_000002_create_posts_table.php
@@ -11,7 +11,7 @@ return new class extends SnapshotMigration
     public function up(): void
     {
         $this->schema->create('posts', function (SnapshotBlueprint $table) {
-            $table->id();
+            $table->uuid()->primary();
             $table->unsignedBigInteger('user_id');
             $table->string('slug');
             $table->string('title');

--- a/tests/Database/Migrations/query/2023_08_25_000003_create_post_post_table.php
+++ b/tests/Database/Migrations/query/2023_08_25_000003_create_post_post_table.php
@@ -11,20 +11,11 @@ return new class extends SnapshotMigration
     public function up(): void
     {
         $this->schema->create('post_post', function (SnapshotBlueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('post_id');
-            $table->unsignedBigInteger('related_id');
+            $table->foreignUuid('post_id')->constrainedToSnapshot('posts', 'uuid')->cascadeOnDelete();
+            $table->foreignUuid('related_id')->constrainedToSnapshot('posts', 'uuid')->cascadeOnDelete();
             $table->timestamps();
 
-            $table->foreign('post_id')
-                ->references('id')
-                ->onSnapshot('posts')
-                ->cascadeOnDelete();
-
-            $table->foreign('related_id')
-                ->references('id')
-                ->onSnapshot('posts')
-                ->cascadeOnDelete();
+            $table->primary(['post_id', 'related_id']);
         });
     }
 };

--- a/tests/Database/Migrations/query/2023_08_25_000004_create_likes_table.php
+++ b/tests/Database/Migrations/query/2023_08_25_000004_create_likes_table.php
@@ -18,7 +18,6 @@ return new class extends Migration
             $table->timestamps();
 
             $table->foreign('user_id')->references('id')->on('users');
-            $table->foreign('post_id')->references('id')->on('posts');
         });
     }
 };

--- a/tests/Database/Migrations/query/2023_08_25_000005_create_seos_table.php
+++ b/tests/Database/Migrations/query/2023_08_25_000005_create_seos_table.php
@@ -17,7 +17,7 @@ return new class extends SnapshotMigration
             $table->text('value');
             $table->timestamps();
 
-            $table->foreign('post_id')->references('id')->on('posts');
+            $table->foreign('post_id')->references('uuid')->on('posts');
         });
     }
 };

--- a/tests/Database/Migrations/query/2023_08_25_000006_create_videos_table.php
+++ b/tests/Database/Migrations/query/2023_08_25_000006_create_videos_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('name');
             $table->timestamps();
 
-            $table->foreign('post_id')->references('id')->on('posts');
+            $table->foreign('post_id')->references('uuid')->on('posts');
         });
     }
 };

--- a/tests/Database/Seeders/Relation/MorphPivotSeeder.php
+++ b/tests/Database/Seeders/Relation/MorphPivotSeeder.php
@@ -44,7 +44,7 @@ class MorphPivotSeeder extends Seeder
         ]);
 
         $installFurnace = Task::factory()->create([
-            'project_id' => $wellington->id,
+            'project_id' => $wellington->ulid,
             'name' => 'Install new Furnace',
         ]);
 
@@ -65,7 +65,7 @@ class MorphPivotSeeder extends Seeder
         ]);
 
         $installLightbulb = Task::factory()->create([
-            'project_id' => $pennsylvania->id,
+            'project_id' => $pennsylvania->ulid,
             'name' => 'Install new Lightbulb',
         ]);
 
@@ -86,7 +86,7 @@ class MorphPivotSeeder extends Seeder
         ]);
 
         $installToilet = Task::factory()->create([
-            'project_id' => $downing->id,
+            'project_id' => $downing->ulid,
             'name' => 'Install new Toilet',
         ]);
 

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -27,7 +27,7 @@ class Category extends Model
 
     public function projects(): BelongsToMany
     {
-        return $this->belongsToMany(Project::class)
+        return $this->belongsToMany(Project::class, 'category_project', 'category_id', 'project_id', 'id', 'ulid')
             ->using(CategorizedProject::class);
     }
 }

--- a/tests/Models/Like.php
+++ b/tests/Models/Like.php
@@ -5,11 +5,13 @@ namespace Plank\Snapshots\Tests\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Plank\Snapshots\Concerns\InteractsWithVersionedContent;
 use Plank\Snapshots\Tests\Database\Factories\LikeFactory;
 
 class Like extends Model
 {
     use HasFactory;
+    use InteractsWithVersionedContent;
 
     protected $guarded = [];
 
@@ -30,6 +32,6 @@ class Like extends Model
 
     public function post(): BelongsTo
     {
-        return $this->belongsTo(Post::class);
+        return $this->belongsTo(Post::class, 'post_id', 'uuid');
     }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -4,6 +4,7 @@ namespace Plank\Snapshots\Tests\Models;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -31,6 +32,9 @@ class Post extends Model implements Versioned
 {
     use AsVersionedContent;
     use HasFactory;
+    use HasUuids;
+
+    protected $primaryKey = 'uuid';
 
     protected $guarded = [];
 
@@ -51,7 +55,7 @@ class Post extends Model implements Versioned
 
     public function related(): BelongsToMany
     {
-        return $this->belongsToMany(Post::class, 'post_post', 'post_id', 'related_id');
+        return $this->belongsToMany(Post::class, 'post_post', 'post_id', 'related_id', 'uuid', 'uuid');
     }
 
     public function tags(): MorphToMany
@@ -61,11 +65,11 @@ class Post extends Model implements Versioned
 
     public function likes(): HasMany
     {
-        return $this->hasMany(Like::class);
+        return $this->hasMany(Like::class, 'post_id', 'uuid');
     }
 
     public function seos(): HasMany
     {
-        return $this->hasMany(Seo::class);
+        return $this->hasMany(Seo::class, 'post_id', 'uuid');
     }
 }

--- a/tests/Models/Project.php
+++ b/tests/Models/Project.php
@@ -2,6 +2,7 @@
 
 namespace Plank\Snapshots\Tests\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,8 +15,11 @@ class Project extends Model implements Versioned
 {
     use AsVersionedContent;
     use HasFactory;
+    use HasUlids;
 
     protected $guarded = [];
+
+    protected $primaryKey = 'ulid';
 
     /**
      * Create a new factory instance for the model.
@@ -29,13 +33,13 @@ class Project extends Model implements Versioned
 
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany(Category::class)
+        return $this->belongsToMany(Category::class, 'category_project', 'project_id', 'category_id', 'ulid', 'id')
             ->using(CategorizedProject::class);
     }
 
     public function products(): BelongsToMany
     {
-        return $this->belongsToMany(Product::class)
+        return $this->belongsToMany(Product::class, 'product_project', 'project_id', 'product_id', 'ulid', 'id')
             ->using(PurchasedProduct::class)
             ->withPivot('quantity');
     }

--- a/tests/Models/Seo.php
+++ b/tests/Models/Seo.php
@@ -28,6 +28,6 @@ class Seo extends Model implements Versioned
 
     public function post(): BelongsTo
     {
-        return $this->belongsTo(Post::class);
+        return $this->belongsTo(Post::class, 'post_id', 'uuid');
     }
 }

--- a/tests/Suites/Feature/ModelQueriesTest.php
+++ b/tests/Suites/Feature/ModelQueriesTest.php
@@ -18,7 +18,7 @@ describe('Versioned models use the version prefixed table when interacting with 
 
     it('can retrieve the correct version of a model', function () {
         // Verify the seeded post was found and has the correct data
-        expect(Post::find(1)->title)->toBe('Post 1');
+        expect(($post = Post::query()->where('title', 'Post 1')->first()))->not->toBeNull();
 
         // Create a new version and make it active
         versions()->setActive(createFirstVersion('query'));
@@ -27,7 +27,7 @@ describe('Versioned models use the version prefixed table when interacting with 
         expect((new Post)->getTable())->toBe('v1_0_0_posts');
 
         // Verify the post was copied over when migrating the version
-        expect(Post::find(1)->title)->toBe('Post 1');
+        expect(Post::find($post->uuid)->title)->toBe('Post 1');
     });
 
     it('can save a model to the correct version table', function () {
@@ -55,7 +55,7 @@ describe('Versioned models use the version prefixed table when interacting with 
         versions()->setActive(createFirstVersion('query'));
 
         // Find the first post
-        expect(($post = Post::find(1))->title)->toBe('Post 1');
+        expect(($post = Post::query()->where('title', 'Post 1')->first()))->not->toBeNull();
 
         // Verify the query will be using the correct table
         expect($post->getTable())->toBe('v1_0_0_posts');
@@ -78,7 +78,7 @@ describe('Versioned models use the version prefixed table when interacting with 
         versions()->setActive(createFirstVersion('query'));
 
         // Find the first post
-        expect(($post = Post::find(1))->title)->toBe('Post 1');
+        expect(($post = Post::query()->where('title', 'Post 1')->first()))->not->toBeNull();
 
         // Verify the query will be using the correct table
         expect($post->getTable())->toBe('v1_0_0_posts');

--- a/tests/Suites/Feature/Relations/BelongsToManyTest.php
+++ b/tests/Suites/Feature/Relations/BelongsToManyTest.php
@@ -21,19 +21,19 @@ describe('BelongsTo relationships use versioned tables when one of the models is
         $post2 = Post::factory()->create();
 
         // Ensure the posts are not yet related to eachother
-        expect($post1->related->pluck('id'))->not()->toContain($post2->id);
+        expect($post1->related->pluck('uuid'))->not()->toContain($post2->uuid);
 
         // Relate the posts to eachother in the next version
         versions()->setActive(createFirstVersion('query'));
 
         $post1 = $post1->activeVersion();
         $post1->related()->attach($post2);
-        expect($post1->related->first()->id)->toBe($post2->id);
+        expect($post1->related->first()->uuid)->toBe($post2->uuid);
 
         // Ensure the posts are still not related in the working copy
         versions()->clearActive();
 
-        expect($post1->activeVersion()->related->pluck('id'))->not()->toContain($post2->id);
+        expect($post1->activeVersion()->related->pluck('uuid'))->not()->toContain($post2->uuid);
     });
 
     it('can detach versioned models to versioned models', function () {
@@ -104,7 +104,7 @@ describe('BelongsTo relationships use versioned tables when one of the models is
         ]);
 
         $post1 = $post1->activeVersion();
-        $post1->related()->sync($post1->related->pluck('id')->push($post4->id));
+        $post1->related()->sync($post1->related->pluck('uuid')->push($post4->uuid));
         $post1->unsetRelation('related');
 
         expect($post1->related)->toHaveCount(3);
@@ -138,7 +138,7 @@ describe('BelongsTo relationships use versioned tables when one of the models is
         ]);
 
         $post1 = $post1->activeVersion();
-        $post1->related()->syncWithoutDetaching($post1->related->pluck('id')->push($post4->id));
+        $post1->related()->syncWithoutDetaching($post1->related->pluck('uuid')->push($post4->uuid));
         $post1->unsetRelation('related');
 
         expect($post1->related)->toHaveCount(3);

--- a/tests/Suites/Feature/Relations/BelongsToTest.php
+++ b/tests/Suites/Feature/Relations/BelongsToTest.php
@@ -47,9 +47,9 @@ describe('BelongsTo relationships use versioned tables when one of the models is
 
     it('can make a non versioned model belong to a versioned model', function () {
         $post = Post::factory()->create();
-        $like = Like::factory()->create(['post_id' => $post->id]);
+        $like = Like::factory()->create(['post_id' => $post->uuid]);
 
-        expect($like->post->id)->toBe($post->id);
+        expect($like->post->uuid)->toBe($post->uuid);
 
         versions()->setActive(createFirstVersion('query'));
 
@@ -64,11 +64,11 @@ describe('BelongsTo relationships use versioned tables when one of the models is
 
         $like = Like::factory()->create();
 
-        expect($like->post->id)->not()->toBe($post->id);
+        expect($like->post->uuid)->not()->toBe($post->uuid);
 
         $like->post()->associate($post)->save();
 
-        expect($like->post->id)->toBe($post->id);
+        expect($like->post->uuid)->toBe($post->uuid);
 
         versions()->setActive(createFirstVersion('query'));
 
@@ -79,7 +79,7 @@ describe('BelongsTo relationships use versioned tables when one of the models is
         $post = Post::factory()->create();
         $seo = $post->seos()->create(Seo::factory()->make()->toArray());
 
-        expect($seo->post->id)->toBe($post->id);
+        expect($seo->post->uuid)->toBe($post->uuid);
 
         versions()->setActive(createFirstVersion('query'));
 
@@ -93,11 +93,11 @@ describe('BelongsTo relationships use versioned tables when one of the models is
 
         $seo = Seo::factory()->create();
 
-        expect($seo->post->id)->not()->toBe($post->id);
+        expect($seo->post->uuid)->not()->toBe($post->uuid);
 
         $seo->post()->associate($post)->save();
 
-        expect($seo->post->id)->toBe($post->id);
+        expect($seo->post->uuid)->toBe($post->uuid);
 
         versions()->setActive(createFirstVersion('query'));
 

--- a/tests/Suites/Feature/Relations/MorphPivotTest.php
+++ b/tests/Suites/Feature/Relations/MorphPivotTest.php
@@ -464,7 +464,7 @@ describe('Custom versioned MorphPivot classes use versioned tables correctly', f
             ->where('name', 'Pennsylvania Ave.')
             ->first();
 
-        $can->projects()->attach($pennsylvania->id);
+        $can->projects()->attach($pennsylvania->ulid);
 
         $projects = $can->projects()->get()->pluck('name');
 
@@ -498,7 +498,7 @@ describe('Custom versioned MorphPivot classes use versioned tables correctly', f
             ->where('name', 'Wellington St.')
             ->first();
 
-        $can->projects()->detach($wellington->id);
+        $can->projects()->detach($wellington->ulid);
 
         $projects = $can->projects()->get()->pluck('name');
 
@@ -571,8 +571,8 @@ describe('Custom versioned MorphPivot classes use versioned tables correctly', f
             ->first();
 
         $can->projects()->sync([
-            $pennsylvania->id,
-            $downing->id,
+            $pennsylvania->ulid,
+            $downing->ulid,
         ]);
 
         $projects = $can->projects()->get()->pluck('name');
@@ -612,8 +612,8 @@ describe('Custom versioned MorphPivot classes use versioned tables correctly', f
             ->first();
 
         $can->projects()->syncWithoutDetaching([
-            $pennsylvania->id,
-            $downing->id,
+            $pennsylvania->ulid,
+            $downing->ulid,
         ]);
 
         $projects = $can->projects()->get()->pluck('name');

--- a/tests/Suites/Feature/Relations/MorphToManyTest.php
+++ b/tests/Suites/Feature/Relations/MorphToManyTest.php
@@ -100,7 +100,7 @@ describe('MorphToMany relationships use versioned tables when one of the models 
         expect($post->tags->count())->toBe(3);
         expect($post->tags->pluck('id'))->not()->toContain($detaching->pluck('id'));
         expect($post->tags->pluck('id'))->toContain(...$toSync->pluck('id')->toArray());
-        expect($toSync->first()->posts->pluck('id'))->toContain($post->id);
+        expect($toSync->first()->posts->pluck('uuid'))->toContain($post->uuid);
 
         versions()->clearActive();
 

--- a/tests/Suites/Feature/Relations/PivotTest.php
+++ b/tests/Suites/Feature/Relations/PivotTest.php
@@ -434,7 +434,7 @@ describe('Custom versioned Pivot classes use version tables correctly', function
             ->first();
 
         $category->projects()->attach([
-            $downing->id,
+            $downing->ulid,
         ]);
 
         $projects = $category->projects()->get()->pluck('name');
@@ -471,7 +471,7 @@ describe('Custom versioned Pivot classes use version tables correctly', function
             Project::query()
                 ->where('name', 'Wellington St.')
                 ->first()
-                ->id,
+                ->ulid,
         ]);
 
         $projects = $category->projects()->get()->pluck('name');
@@ -541,7 +541,7 @@ describe('Custom versioned Pivot classes use version tables correctly', function
             ->first();
 
         $category->projects()->sync([
-            $downing->id,
+            $downing->ulid,
         ]);
 
         $projects = $category->projects()->get()->pluck('name');
@@ -579,7 +579,7 @@ describe('Custom versioned Pivot classes use version tables correctly', function
             ->first();
 
         $category->projects()->syncWithoutDetaching([
-            $downing->id,
+            $downing->ulid,
         ]);
 
         $projects = $category->projects()->get()->pluck('name');


### PR DESCRIPTION
## Summary
There was no way to support referencing snapshotted tableds for the `Illuminate\Database\Schema\Blueprint` methods `foreignId`, `foreignUuid` and `foreignUlid`.

We have added the method `constrainedToSnapshot()` on a custom `SnapshotForeignIdColumnDefinition` class, where you can to support this syntax style.

## Tests
1. Made Post model use Uuid to test the `foreignUuid` method
2. Made Project model use Ulid to test the `foreignUlid` method
3. Used `foreignId` syntax in some of the test migrations