### PR TITLE
Configurable Version Factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ php artisan vendor:publish --provider="Plank\Snapshots\SnapshotsServiceProvider"
 
 The `model` option is the fully qualified class name of the model that will be used to store the versions of your app. The default value is `Plank\Snapshots\Models\Version`. Any model provided must implement the `Plank\Snapshots\Contracts\Version` interface.
 
+### Version Factory
+
+The `factory` option is the fully qualified class name of the model factory that will be used to generate Version instances for testing and seeding your application. The default value is `Plank\Snapshots\Factories\VersionFactory`.
+
 ### Repository
 
 The `repository` option is the fully qualified class name of the repository that will be used to retrieve the versions of your app. The default value is `Plank\Snapshots\Repository\VersionRepository`. Any repository provided must implement the `Plank\Snapshots\Contracts\ManagesVersions` interface.

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Plank\\Snapshots\\Tests\\": "tests/",
-            "Plank\\Snapshots\\Database\\Factories\\": "database/factories"
+            "Plank\\Snapshots\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/config/snapshots.php
+++ b/config/snapshots.php
@@ -17,7 +17,7 @@ return [
     | Version Factory
     |--------------------------------------------------------------------------
     |
-    | This is the factory which will be used to generate new versions for 
+    | This is the factory which will be used to generate new versions for
     | tests and seeders.
     |
     */

--- a/config/snapshots.php
+++ b/config/snapshots.php
@@ -14,6 +14,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Version Factory
+    |--------------------------------------------------------------------------
+    |
+    | This is the factory which will be used to generate new versions for 
+    | tests and seeders.
+    |
+    */
+    'factory' => \Plank\Snapshots\Factories\VersionFactory::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Version Repository
     |--------------------------------------------------------------------------
     |

--- a/src/Factories/VersionFactory.php
+++ b/src/Factories/VersionFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Plank\Snapshots\Database\Factories;
+namespace Plank\Snapshots\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Plank\Snapshots\Models\Version;

--- a/src/Models/Version.php
+++ b/src/Models/Version.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Plank\Snapshots\Concerns\AsVersion;
 use Plank\Snapshots\Contracts\Version as VersionContract;
-use Plank\Snapshots\Database\Factories\VersionFactory;
 use Plank\Snapshots\Observers\VersionObserver;
 use Plank\Snapshots\ValueObjects\VersionNumber;
 
@@ -45,7 +44,7 @@ class Version extends Model implements VersionContract
      */
     protected static function newFactory()
     {
-        return VersionFactory::new();
+        return config('snapshots.factory')::new();
     }
 
     /**


### PR DESCRIPTION
## Summary

To allow package consumers to use the package's VersionFactory, we include it in the packages namespace and allow the consumer to override it using the config file.