### PR TITLE
Abstract the History model to the Configured version

### DIFF
--- a/src/Listeners/LabelHistory.php
+++ b/src/Listeners/LabelHistory.php
@@ -25,7 +25,10 @@ class LabelHistory
             throw LabelingException::create($event->model);
         }
 
-        History::query()
+        /** @var class-string<History>|null */
+        $history = config('snapshots.models.history');
+
+        $history::query()
             ->where('trackable_type', $event->model)
             ->whereNull('version_id')
             ->cursor()
@@ -65,7 +68,10 @@ class LabelHistory
         /** @var CausesChanges|null $causer */
         $causer = app(ResolvesCauser::class)->active();
 
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => Operation::Snapshotted,
             'causer_id' => $causer?->getKey(),
             'causer_type' => $causer?->getMorphClass(),

--- a/src/Observers/HistoryObserver.php
+++ b/src/Observers/HistoryObserver.php
@@ -40,7 +40,10 @@ class HistoryObserver
             return;
         }
 
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => Operation::Created,
             'causer_id' => $this->causer?->getKey(),
             'causer_type' => $this->causer?->getMorphClass(),
@@ -69,7 +72,10 @@ class HistoryObserver
             }
         }
 
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => Operation::Updated,
             'causer_id' => $this->causer?->getKey(),
             'causer_type' => $this->causer?->getMorphClass(),
@@ -89,7 +95,10 @@ class HistoryObserver
             return;
         }
 
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => $softDeletes ? Operation::SoftDeleted : Operation::Deleted,
             'causer_id' => $this->causer?->getKey(),
             'causer_type' => $this->causer?->getMorphClass(),
@@ -103,7 +112,10 @@ class HistoryObserver
 
     public function restored(Model&Trackable $model)
     {
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => Operation::Restored,
             'causer_id' => $this->causer?->getKey(),
             'causer_type' => $this->causer?->getMorphClass(),
@@ -117,7 +129,10 @@ class HistoryObserver
 
     public function forceDeleted(Model&Trackable $model)
     {
-        History::create([
+        /** @var class-string<History>|null $history */
+        $history = config('snapshots.models.history');
+
+        $history::create([
             'operation' => Operation::Deleted,
             'causer_id' => $this->causer?->getKey(),
             'causer_type' => $this->causer?->getMorphClass(),


### PR DESCRIPTION
The History Observer and Labeler should not rely on the Package's History model implementation, but instead rely on the configured model.