### PR TITLE
Fix `dropForeign` throwing exception for missing fk constraint during versioning

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,9 @@
         <testsuite name="Unit Tests">
             <directory>tests/Suites/Unit</directory>
         </testsuite>
+        <testsuite name="Regression">
+            <directory>tests/Suites/Regression</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <report>

--- a/src/Facades/Versions.php
+++ b/src/Facades/Versions.php
@@ -8,13 +8,13 @@ use Plank\Snapshots\Contracts\ManagesVersions;
 use Plank\Snapshots\Contracts\Version;
 
 /**
- * @method void setActive(?Version $version)
- * @method void clearActive()
- * @method Version|null active()
- * @method Version|null latest()
- * @method Version|null find($key)
- * @method Version|null byNumber(string $number)
- * @method Collection all()
+ * @method static void setActive(?Version $version)
+ * @method static void clearActive()
+ * @method static Version|null active()
+ * @method static Version|null latest()
+ * @method static Version|null find($key)
+ * @method static Version|null byNumber(string $number)
+ * @method static Collection all()
  */
 class Versions extends Facade
 {

--- a/src/Facades/Versions.php
+++ b/src/Facades/Versions.php
@@ -2,9 +2,20 @@
 
 namespace Plank\Snapshots\Facades;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 use Plank\Snapshots\Contracts\ManagesVersions;
+use Plank\Snapshots\Contracts\Version;
 
+/**
+ * @method void setActive(?Version $version)
+ * @method void clearActive()
+ * @method Version|null active()
+ * @method Version|null latest()
+ * @method Version|null find($key)
+ * @method Version|null byNumber(string $number)
+ * @method Collection all()
+ */
 class Versions extends Facade
 {
     /**

--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -3,6 +3,7 @@
 namespace Plank\Snapshots\Migrator;
 
 use Illuminate\Database\Schema\Blueprint;
+use Plank\Snapshots\Facades\Versions;
 
 class SnapshotBlueprint extends Blueprint
 {
@@ -62,5 +63,16 @@ class SnapshotBlueprint extends Blueprint
             'name' => $column,
             'length' => $length,
         ]));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    protected function dropIndexCommand($command, $type, $index)
+    {
+        $index = Versions::active()?->addMigrationPrefix($index);
+        return parent::dropIndexCommand($command, $type, $index);
     }
 }

--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -75,6 +75,7 @@ class SnapshotBlueprint extends Blueprint
         if ($version = Versions::active()) {
             $index = $version->addMigrationPrefix($index);
         }
+
         return parent::dropIndexCommand($command, $type, $index);
     }
 }

--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -67,15 +67,23 @@ class SnapshotBlueprint extends Blueprint
 
     /**
      * {@inheritDoc}
-     *
-     * @return \Illuminate\Support\Fluent
      */
-    protected function dropIndexCommand($command, $type, $index)
+    protected function indexCommand($type, $columns, $index, $algorithm = null)
     {
+        $columns = (array) $columns;
+
+        // If no name was specified for this index, we will create one using a basic
+        // convention of the table name, followed by the columns, followed by an
+        // index type, such as primary or index, which makes the index unique.
+        $index = $index ?: $this->createIndexName($type, $columns);
+
         if ($version = Versions::active()) {
+            $index = $version->stripMigrationPrefix($index);
             $index = $version->addMigrationPrefix($index);
         }
 
-        return parent::dropIndexCommand($command, $type, $index);
+        return $this->addCommand(
+            $type, compact('index', 'columns', 'algorithm')
+        );
     }
 }

--- a/src/Migrator/SnapshotBlueprint.php
+++ b/src/Migrator/SnapshotBlueprint.php
@@ -72,7 +72,9 @@ class SnapshotBlueprint extends Blueprint
      */
     protected function dropIndexCommand($command, $type, $index)
     {
-        $index = Versions::active()?->addMigrationPrefix($index);
+        if ($version = Versions::active()) {
+            $index = $version->addMigrationPrefix($index);
+        }
         return parent::dropIndexCommand($command, $type, $index);
     }
 }

--- a/src/Migrator/SnapshotMigrator.php
+++ b/src/Migrator/SnapshotMigrator.php
@@ -32,7 +32,7 @@ class SnapshotMigrator extends Migrator
         MigrationRepositoryInterface $repository,
         ConnectionResolverInterface $resolver,
         Filesystem $files,
-        Dispatcher $dispatcher = null,
+        ?Dispatcher $dispatcher,
         ManagesVersions $versions,
         ManagesCreatedTables $tables,
         Version $version
@@ -288,7 +288,7 @@ class SnapshotMigrator extends Migrator
         $this->tables->flush();
     }
 
-    protected function versionedFile(?string $file, Version $version = null): ?string
+    protected function versionedFile(?string $file, ?Version $version = null): ?string
     {
         if ($file === null) {
             return null;

--- a/tests/Database/Migrations/schema/create/create_documents_table.php
+++ b/tests/Database/Migrations/schema/create/create_documents_table.php
@@ -13,6 +13,9 @@ return new class extends SnapshotMigration
             $table->string('text');
             $table->timestamp('released_at')->nullable();
             $table->timestamps();
+
+            $table->index('title', 'idx_title');
+            $table->index('released_at');
         });
     }
 

--- a/tests/Database/Migrations/schema/drop_computed_index/drop_computed_index.php
+++ b/tests/Database/Migrations/schema/drop_computed_index/drop_computed_index.php
@@ -1,0 +1,14 @@
+<?php
+
+use Plank\Snapshots\Migrator\SnapshotBlueprint;
+use Plank\Snapshots\Migrator\SnapshotMigration;
+
+return new class extends SnapshotMigration
+{
+    public function up()
+    {
+        $this->schema->table('documents', function (SnapshotBlueprint $table) {
+            $table->dropIndex(['released_at']);
+        });
+    }
+};

--- a/tests/Database/Migrations/schema/drop_named_index/drop_named_index.php
+++ b/tests/Database/Migrations/schema/drop_named_index/drop_named_index.php
@@ -1,0 +1,14 @@
+<?php
+
+use Plank\Snapshots\Migrator\SnapshotBlueprint;
+use Plank\Snapshots\Migrator\SnapshotMigration;
+
+return new class extends SnapshotMigration
+{
+    public function up()
+    {
+        $this->schema->table('documents', function (SnapshotBlueprint $table) {
+            $table->dropIndex('idx_title');
+        });
+    }
+};

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -36,7 +36,7 @@ function migrationPath(string $path = ''): string
 /**
  * Create the first Version
  */
-function createFirstVersion(string $migrationPath = null): Version
+function createFirstVersion(?string $migrationPath = null): Version
 {
     if ($migrationPath) {
         setMigrationPath($migrationPath);
@@ -52,7 +52,7 @@ function createFirstVersion(string $migrationPath = null): Version
 /**
  * Create the next Patch Version
  */
-function createPatchVersion(string $migrationPath = null): Version
+function createPatchVersion(?string $migrationPath = null): Version
 {
     if ($migrationPath) {
         setMigrationPath($migrationPath);
@@ -74,7 +74,7 @@ function createPatchVersion(string $migrationPath = null): Version
 /**
  * Create the next Minor Version
  */
-function createMinorVersion(string $migrationPath = null): Version
+function createMinorVersion(?string $migrationPath = null): Version
 {
     if ($migrationPath) {
         setMigrationPath($migrationPath);
@@ -96,7 +96,7 @@ function createMinorVersion(string $migrationPath = null): Version
 /**
  * Create the next Major Version
  */
-function createMajorVersion(string $migrationPath = null): Version
+function createMajorVersion(?string $migrationPath = null): Version
 {
     if ($migrationPath) {
         setMigrationPath($migrationPath);

--- a/tests/Suites/Regression/IndexesTest.php
+++ b/tests/Suites/Regression/IndexesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Plank\Snapshots\Tests\Models\Document;
+
+use function Pest\Laravel\artisan;
+
+describe('SnapshotBlueprint uses versions for named indexes', function () {
+    beforeEach(function () {
+        artisan('migrate', [
+            '--path' => migrationPath('schema/create'),
+            '--realpath' => true,
+        ])->run();
+    });
+
+    it('can drop named indexes from tables', function () {
+        $tableName = (new Document())->getTable();
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+
+        expect($indexes)->toHaveCount(2);
+        expect($indexes->pluck('name'))->toContain('idx_title');
+
+        artisan('migrate', [
+            '--path' => migrationPath('schema/drop_named_index'),
+            '--realpath' => true,
+        ])->run();
+
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+        expect($indexes)->toHaveCount(1);
+
+        versions()->setActive(createFirstVersion('schema/create'));
+
+        $tableName = (new Document())->getTable();
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+
+        expect($indexes)->toHaveCount(2);
+        expect($indexes->pluck('name'))->toContain('v1_0_0_idx_title');
+
+        artisan('migrate', [
+            '--path' => migrationPath('schema/drop_named_index'),
+            '--realpath' => true,
+        ])->run();
+
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+        expect($indexes)->toHaveCount(1);
+    });
+});
+
+describe('SnapshotBlueprint uses versions for computed indexes', function () {
+    beforeEach(function () {
+        artisan('migrate', [
+            '--path' => migrationPath('schema/create'),
+            '--realpath' => true,
+        ])->run();
+    });
+
+    it('can drop computed indexes from tables', function () {
+        $tableName = (new Document())->getTable();
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+        expect($indexes)->toHaveCount(2);
+        expect($indexes->pluck('name'))->toContain($tableName.'_released_at_index');
+
+        artisan('migrate', [
+            '--path' => migrationPath('schema/drop_computed_index'),
+            '--realpath' => true,
+        ])->run();
+
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+        expect($indexes)->toHaveCount(1);
+
+        versions()->setActive(createFirstVersion('schema/create'));
+
+        $tableName = (new Document())->getTable();
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+
+        expect($indexes)->toHaveCount(2);
+        expect($indexes->pluck('name'))->toContain($tableName.'_released_at_index');
+
+        artisan('migrate', [
+            '--path' => migrationPath('schema/drop_computed_index'),
+            '--realpath' => true,
+        ])->run();
+
+        $indexes = Collection::wrap(DB::select("PRAGMA index_list('$tableName')"));
+        expect($indexes)->toHaveCount(1);
+    });
+});


### PR DESCRIPTION
###### closes #15

## Summary
<!-- Short description of the changes/fixes made. What does this PR solve? -->
Adds a check that will prefix dropped foreign key constraints while a version is being created. This needs to happen because when tables are copied, the (correctly) rename the foreign key constraints, but the `dropIndexCommand` does not account for this changed name.

Short circuiting via the passed `SnapshotBlueprint` in `SnapshotSchemaBuilder`'s `->blueprintResolver(...)` was attempted, but this proved unsuccessful 


## Tests
<!-- List the tests that cover the functionality of this PR -->
due to the use of SQLite in the testing pipeline, automated tests for this cannout be added at the moment (SQLite doesn't support `->dropForeign()`). To manually test this works:
1. Create 2 tables, in which the second table has a foreign key constraint against the first
2. Create a 3rd migration which attempts to remove said foreign key constraint
3. Attempt to create a new version / snapshot
4. Observe that the migrations complete successfully
