### PR TITLE
Abstract Version Keys

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
+        php: [8.4]
         laravel: [11.*]
         stability: [prefer-stable]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "doctrine/dbal": "^3.6",
+        "doctrine/dbal": "^3.6|^4",
         "illuminate/contracts": "^10|^11",
         "plank/laravel-hush": "^1.0",
         "spatie/laravel-package-tools": "^1.14.0"

--- a/src/Concerns/AsVersion.php
+++ b/src/Concerns/AsVersion.php
@@ -25,7 +25,7 @@ trait AsVersion
      */
     public function addMigrationPrefix(string $name): string
     {
-        return 'v'.$this->number->snake().'_'.$name;
+        return $this->number->key().'_'.$name;
     }
 
     /**
@@ -57,7 +57,7 @@ trait AsVersion
      */
     public function addTablePrefix(string $table): string
     {
-        return 'v'.$this->number->snake().'_'.$this->stripTablePrefix($table);
+        return $this->number->key().'_'.$this->stripTablePrefix($table);
     }
 
     /**

--- a/src/Contracts/VersionKey.php
+++ b/src/Contracts/VersionKey.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Plank\Snapshots\Contracts;
+
+use Stringable;
+
+interface VersionKey extends Stringable
+{
+    /**
+     * Build an instance from an identifying string
+     * 
+     * @return static
+     */
+    public static function fromVersionString(string $key): static;
+
+    /**
+     * Get an identifying string representation of the version
+     */
+    public function key(): string;
+}

--- a/src/Contracts/VersionKey.php
+++ b/src/Contracts/VersionKey.php
@@ -8,8 +8,6 @@ interface VersionKey extends Stringable
 {
     /**
      * Build an instance from an identifying string
-     * 
-     * @return static
      */
     public static function fromVersionString(string $key): static;
 

--- a/src/ValueObjects/VersionNumber.php
+++ b/src/ValueObjects/VersionNumber.php
@@ -2,9 +2,12 @@
 
 namespace Plank\Snapshots\ValueObjects;
 
-class VersionNumber
+use Plank\Snapshots\Contracts\VersionKey;
+
+class VersionNumber implements VersionKey
 {
-    protected const REGEX = '/^(\d+\.\d+\.\d+)$/';
+    protected const DOT_REGEX = '/^(\d+\.\d+\.\d+)$/';
+    protected const KEY_REGEX = '/^(v{0,1}\d+\_\d+\_\d+)$/';
 
     public function __construct(
         protected int $major,
@@ -12,20 +15,28 @@ class VersionNumber
         protected int $patch
     ) {}
 
-    public static function fromVersionString(string $number): self
+    public static function fromVersionString(string $number): static
     {
-        if (! static::isValidVersionString($number)) {
+        if (preg_match(static::DOT_REGEX, $number) === 1) {
+            [$major, $minor, $patch] = explode('.', $number);
+        } elseif (preg_match(static::KEY_REGEX, $number) === 1) {
+            [$major, $minor, $patch] = explode('_', $number);
+        } else {
             throw new \InvalidArgumentException('Invalid version number: '.$number);
         }
 
-        [$major, $minor, $patch] = explode('.', $number);
+        return new static(str($major)->after('v')->toInteger(), (int) $minor, (int) $patch);
+    }
 
-        return new static((int) $major, (int) $minor, (int) $patch);
+    public function key(): string
+    {
+        return 'v'.$this->major.'_'.$this->minor.'_'.$this->patch;
     }
 
     protected static function isValidVersionString(string $version)
     {
-        return preg_match(static::REGEX, $version) === 1;
+        return preg_match(static::DOT_REGEX, $version) === 1
+            || preg_match(static::KEY_REGEX, $version) === 1;
     }
 
     public function major(): int
@@ -58,45 +69,40 @@ class VersionNumber
         return new static($this->major, $this->minor, $this->patch + 1);
     }
 
-    public function snake(): string
-    {
-        return $this->major.'_'.$this->minor.'_'.$this->patch;
-    }
-
     public function kebab(): string
     {
         return $this->major.'-'.$this->minor.'-'.$this->patch;
     }
 
-    public function isGreaterThan(VersionNumber|string $other): bool
+    public function isGreaterThan(VersionKey|string $other): bool
     {
         $other = static::wrap($other);
 
         return $this->compare($other) > 0;
     }
 
-    public function isGreaterThanOrEqualTo(VersionNumber|string $other): bool
+    public function isGreaterThanOrEqualTo(VersionKey|string $other): bool
     {
         $other = static::wrap($other);
 
         return $this->compare($other) >= 0;
     }
 
-    public function isLessThan(VersionNumber|string $other): bool
+    public function isLessThan(VersionKey|string $other): bool
     {
         $other = static::wrap($other);
 
         return $this->compare($other) < 0;
     }
 
-    public function isLessThanOrEqualTo(VersionNumber|string $other): bool
+    public function isLessThanOrEqualTo(VersionKey|string $other): bool
     {
         $other = static::wrap($other);
 
         return $this->compare($other) <= 0;
     }
 
-    public function isEqualTo(VersionNumber|string $other): bool
+    public function isEqualTo(VersionKey|string $other): bool
     {
         $other = static::wrap($other);
 

--- a/src/ValueObjects/VersionNumber.php
+++ b/src/ValueObjects/VersionNumber.php
@@ -7,6 +7,7 @@ use Plank\Snapshots\Contracts\VersionKey;
 class VersionNumber implements VersionKey
 {
     protected const DOT_REGEX = '/^(\d+\.\d+\.\d+)$/';
+
     protected const KEY_REGEX = '/^(v{0,1}\d+\_\d+\_\d+)$/';
 
     public function __construct(

--- a/tests/Suites/Feature/Migrations/PretendTest.php
+++ b/tests/Suites/Feature/Migrations/PretendTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Plank\Snapshots\Contracts\ManagesCreatedTables;
 use Plank\Snapshots\Contracts\ManagesVersions;
 use Plank\Snapshots\Contracts\Version;
@@ -91,7 +91,7 @@ describe('SnapshotMigrations can be pretended', function () {
 
             protected function getQueries($migration, $method)
             {
-                throw SchemaException::tableDoesNotExist('test');
+                throw new TableDoesNotExist('test');
             }
 
             protected function write($component, ...$arguments)

--- a/tests/Suites/Unit/VersionNumberTest.php
+++ b/tests/Suites/Unit/VersionNumberTest.php
@@ -45,10 +45,10 @@ describe('VersionNumber creates, compares and transforms correctly', function ()
         expect($next->patch())->toEqual(1);
     });
 
-    it('can return a snake cased string of the version', function () {
+    it('can return a string key of the version', function () {
         $version = VersionNumber::fromVersionString('1.0.0');
 
-        expect($version->snake())->toEqual('1_0_0');
+        expect($version->key())->toEqual('v1_0_0');
     });
 
     it('can return a kebab cased string of the version', function () {


### PR DESCRIPTION
## Summary
Non-breaking change to allow package consumers to more easily define their own version numbers.

Remove and rename methods from contract while keeping VersionNumber mostly unchanged.