### PR TITLE
Do not interfere with laravel relation count hashes

### DIFF
--- a/src/Concerns/AsVersionedContent.php
+++ b/src/Concerns/AsVersionedContent.php
@@ -33,6 +33,10 @@ trait AsVersionedContent
     {
         $table = parent::getTable();
 
+        if (str_contains($table, 'laravel_reserved_')) {
+            return $table;
+        }
+
         /** @var Version $class */
         $class = config('snapshots.models.version');
 


### PR DESCRIPTION
## Summary
When laravel adds relation count hashes to queries it uses `laravel_reserved_[0-9]+` aliases. We do not want snapshots to prefix these aliases with versions, as the alias points to a prefixed/versioned table already.