### PR TITLE
Less Opinionated VersionNumber

### DIFF
--- a/src/Casts/AsVersionNumber.php
+++ b/src/Casts/AsVersionNumber.php
@@ -9,13 +9,13 @@ class AsVersionNumber implements CastsAttributes
 {
     public function get($model, string $key, $value, array $attributes)
     {
-        return VersionNumberValueObject::fromVersionString($value ?? '0.0.0');
+        return VersionNumberValueObject::fromString($value ?? '0.0.0');
     }
 
     public function set($model, string $key, $value, array $attributes)
     {
         if (is_string($value)) {
-            $value = VersionNumberValueObject::fromVersionString($value);
+            $value = VersionNumberValueObject::fromString($value);
         }
 
         if (! $value instanceof VersionNumberValueObject) {

--- a/src/Connection/SnapshotConnectionInitializer.php
+++ b/src/Connection/SnapshotConnectionInitializer.php
@@ -17,11 +17,11 @@ class SnapshotConnectionInitializer
         string $name,
     ) {
         $connection = $db->connection($name);
-        $previousTablePrefix = $connection->getTablePrefix();
+        $configuredPrefix = $connection->getTablePrefix();
 
         $prefix = ($active = Versions::active())
-            ? ($active->key()->key().'_'.$previousTablePrefix)
-            : $previousTablePrefix;
+            ? $active->key()->prefix($configuredPrefix)
+            : $configuredPrefix;
 
         $config = $connection->getConfig();
         $config['prefix_indexes'] = true;

--- a/src/Contracts/VersionKey.php
+++ b/src/Contracts/VersionKey.php
@@ -7,6 +7,26 @@ use Stringable;
 interface VersionKey extends Stringable
 {
     /**
+     * Build an instance from any string
+     */
+    public static function fromString(string $key): static;
+
+    /**
+     * Get an identifying string representation of the version
+     */
+    public function toString(): string;
+
+    /**
+     * Prefix the version to the beginning of the string
+     */
+    public function snake(): string;
+
+    /**
+     * Strip any occurence of the version from the string
+     */
+    public function kebab(): string;
+
+    /**
      * Prefix the version to the beginning of the string
      */
     public function prefix(string $string): string;
@@ -15,29 +35,4 @@ interface VersionKey extends Stringable
      * Strip any occurence of the version from the string
      */
     public static function strip(string $string): string;
-
-    /**
-     * Build an instance from any string
-     */
-    public static function fromString(string $key): static;
-
-    /**
-     * Build an instance from a migration name
-     */
-    public static function fromMigrationString(string $name): static;
-
-    /**
-     * Build an instance from a version formatted string
-     */
-    public static function fromVersionString(string $key): static;
-
-    /**
-     * Build an instance from an identifying string
-     */
-    public static function fromKeyString(string $key): static;
-
-    /**
-     * Get an identifying string representation of the version
-     */
-    public function key(): string;
 }

--- a/src/ValueObjects/VersionNumber.php
+++ b/src/ValueObjects/VersionNumber.php
@@ -47,7 +47,7 @@ class VersionNumber implements VersionKey
         if (count($matches) !== 5) {
             throw new \InvalidArgumentException;
         }
-    
+
         return new static(
             major: (int) $matches[2],
             minor: (int) $matches[3],

--- a/tests/Suites/Feature/VersionsTest.php
+++ b/tests/Suites/Feature/VersionsTest.php
@@ -19,7 +19,7 @@ describe('Versions are migrated correctly', function () {
         createFirstVersion();
         createPatchVersion();
 
-        expect(versions()->latest()->number)->toEqual(VersionNumber::fromVersionString('1.0.1'));
+        expect(versions()->latest()->number)->toEqual(VersionNumber::fromString('1.0.1'));
     });
 
     it('throws an error when trying to cast the version number to a nonstring or value object', function () {

--- a/tests/Suites/Unit/VersionNumberTest.php
+++ b/tests/Suites/Unit/VersionNumberTest.php
@@ -4,7 +4,7 @@ use Plank\Snapshots\ValueObjects\VersionNumber;
 
 describe('VersionNumber creates, compares and transforms correctly', function () {
     it('can be created from a string', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         expect($number->major())->toEqual(1);
         expect($number->minor())->toEqual(0);
@@ -12,11 +12,11 @@ describe('VersionNumber creates, compares and transforms correctly', function ()
     });
 
     it('throws an exception if the string is invalid', function () {
-        VersionNumber::fromVersionString('10000');
+        VersionNumber::fromString('10000');
     })->throws(InvalidArgumentException::class);
 
     it('can return the next major version', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         $next = $number->nextMajor();
 
@@ -26,7 +26,7 @@ describe('VersionNumber creates, compares and transforms correctly', function ()
     });
 
     it('can return the next minor version', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         $next = $number->nextMinor();
 
@@ -36,7 +36,7 @@ describe('VersionNumber creates, compares and transforms correctly', function ()
     });
 
     it('can return the next patch version', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         $next = $number->nextPatch();
 
@@ -46,60 +46,66 @@ describe('VersionNumber creates, compares and transforms correctly', function ()
     });
 
     it('can return a string key of the version', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->key())->toEqual('v1_0_0');
+        expect($number->snake())->toEqual('1_0_0');
     });
 
     it('can return a kebab cased string of the version', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         expect($number->kebab())->toEqual('1-0-0');
     });
 
     it('casts to a string in dot notation', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
         expect((string) $number)->toEqual('1.0.0');
     });
 
-    it('can determine if another version number is greater than itself', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+    it('prefixes to snake notation with a v', function () {
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->isGreaterThan(VersionNumber::fromVersionString('0.9.9')))->toBeTrue();
-        expect($number->isGreaterThan(VersionNumber::fromVersionString('1.0.0')))->toBeFalse();
-        expect($number->isGreaterThan(VersionNumber::fromVersionString('1.0.1')))->toBeFalse();
+        expect($number->prefix(''))->toEqual('v1_0_0_');
+    });
+
+    it('can determine if another version number is greater than itself', function () {
+        $number = VersionNumber::fromString('1.0.0');
+
+        expect($number->isGreaterThan(VersionNumber::fromString('0.9.9')))->toBeTrue();
+        expect($number->isGreaterThan(VersionNumber::fromString('1.0.0')))->toBeFalse();
+        expect($number->isGreaterThan(VersionNumber::fromString('1.0.1')))->toBeFalse();
     });
 
     it('can determine if another version number is greater than or equal to itself', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromVersionString('0.9.9')))->toBeTrue();
-        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromVersionString('1.0.0')))->toBeTrue();
-        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromVersionString('1.0.1')))->toBeFalse();
+        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromString('0.9.9')))->toBeTrue();
+        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromString('1.0.0')))->toBeTrue();
+        expect($number->isGreaterThanOrEqualTo(VersionNumber::fromString('1.0.1')))->toBeFalse();
     });
 
     it('can determine if another version number is less than itself', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->isLessThan(VersionNumber::fromVersionString('1.0.1')))->toBeTrue();
-        expect($number->isLessThan(VersionNumber::fromVersionString('1.0.0')))->toBeFalse();
-        expect($number->isLessThan(VersionNumber::fromVersionString('0.9.9')))->toBeFalse();
+        expect($number->isLessThan(VersionNumber::fromString('1.0.1')))->toBeTrue();
+        expect($number->isLessThan(VersionNumber::fromString('1.0.0')))->toBeFalse();
+        expect($number->isLessThan(VersionNumber::fromString('0.9.9')))->toBeFalse();
     });
 
     it('can determine if another version number is less than or equal to itself', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->isLessThanOrEqualTo(VersionNumber::fromVersionString('1.0.1')))->toBeTrue();
-        expect($number->isLessThanOrEqualTo(VersionNumber::fromVersionString('1.0.0')))->toBeTrue();
-        expect($number->isLessThanOrEqualTo(VersionNumber::fromVersionString('0.9.9')))->toBeFalse();
+        expect($number->isLessThanOrEqualTo(VersionNumber::fromString('1.0.1')))->toBeTrue();
+        expect($number->isLessThanOrEqualTo(VersionNumber::fromString('1.0.0')))->toBeTrue();
+        expect($number->isLessThanOrEqualTo(VersionNumber::fromString('0.9.9')))->toBeFalse();
     });
 
     it('can determine if another version number is equal to itself', function () {
-        $number = VersionNumber::fromVersionString('1.0.0');
+        $number = VersionNumber::fromString('1.0.0');
 
-        expect($number->isEqualTo(VersionNumber::fromVersionString('1.0.0')))->toBeTrue();
-        expect($number->isEqualTo(VersionNumber::fromVersionString('1.0.1')))->toBeFalse();
-        expect($number->isEqualTo(VersionNumber::fromVersionString('0.9.9')))->toBeFalse();
+        expect($number->isEqualTo(VersionNumber::fromString('1.0.0')))->toBeTrue();
+        expect($number->isEqualTo(VersionNumber::fromString('1.0.1')))->toBeFalse();
+        expect($number->isEqualTo(VersionNumber::fromString('0.9.9')))->toBeFalse();
     });
 });


### PR DESCRIPTION
## Summary
The VersionNumber value object was forcing some implementation details that are unnecessary for critical functions. Pare back the interface to allow the consuming applications more flexibility in defining their own versioning semantics.